### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
+name = "castaway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b662d08e94a6c8e715abef5e10e6fdf47c2be6375a5bb246b65c177d575eb7"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,11 +178,13 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd1dddf0cf9b27908dba335f898b9915dfca771737104cd711438bbab20ea6ed"
+checksum = "fb6f80f92629b81f5b17b616a99f72870556ca457bbbd99aeda7bb5d194316a2"
 dependencies = [
- "static_assertions",
+ "castaway",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]
@@ -653,6 +664,12 @@ checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jobserver"
@@ -1277,6 +1294,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "ryu"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,12 +1415,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 fnv = "1.0.7"
-compact_str = "0.2.0"
+compact_str = "0.4"
 thiserror = "1.0"
 smallvec = { version = "1.7.0", features = ["union", "const_generics", "const_new"] }
 itertools = "0.10.3"

--- a/src/analyze/analyzer.rs
+++ b/src/analyze/analyzer.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::rc::Rc;
 
 use ahash::AHashMap;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use smallvec::SmallVec;
 
 use crate::analyze::scope::{Scope, ScopeStack};
@@ -14,7 +14,7 @@ use crate::analyze::typed_ast::{
 };
 use crate::parser::{parse, Parser};
 
-pub type Imports = Rc<RefCell<AHashMap<CompactStr, Module>>>;
+pub type Imports = Rc<RefCell<AHashMap<CompactString, Module>>>;
 
 pub struct Analyzer {
     source: String,
@@ -123,7 +123,7 @@ impl Analyzer {
                 todo!()
             }
             parse::decl::Decl::Import(mut path) => {
-                let name: CompactStr = path
+                let name: CompactString = path
                     .segment
                     .pop()
                     .ok_or_else(|| {
@@ -135,7 +135,7 @@ impl Analyzer {
                     .segment
                     .into_iter()
                     .map(|id| id.to_str().into())
-                    .collect::<SmallVec<[CompactStr; 3]>>();
+                    .collect::<SmallVec<[CompactString; 3]>>();
                 let path = if path.is_empty() {
                     name.clone()
                 } else {
@@ -456,11 +456,11 @@ where
 }
 
 trait ExpectLiteral {
-    fn expect_str(self) -> anyhow::Result<CompactStr>;
+    fn expect_str(self) -> anyhow::Result<CompactString>;
 }
 
 impl ExpectLiteral for Option<parse::expr::LiteralExpr<'_>> {
-    fn expect_str(self) -> anyhow::Result<CompactStr> {
+    fn expect_str(self) -> anyhow::Result<CompactString> {
         match self.ok_or_else(|| {
             anyhow::anyhow!("expected a literal str but None")
         })? {

--- a/src/analyze/typed_ast/decl.rs
+++ b/src/analyze/typed_ast/decl.rs
@@ -1,4 +1,4 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use smallvec::SmallVec;
 
 use crate::analyze::typed_ast::{Block, FuncType, Ident, Type};
@@ -6,7 +6,7 @@ use crate::analyze::typed_ast::{Block, FuncType, Ident, Type};
 #[derive(Debug, Clone)]
 pub enum Decl {
     FnDecl(FnDecl),
-    Import(CompactStr, Box<Decl>),
+    Import(CompactString, Box<Decl>),
 }
 
 #[derive(Debug, Clone)]

--- a/src/analyze/typed_ast/expr.rs
+++ b/src/analyze/typed_ast/expr.rs
@@ -1,7 +1,7 @@
 use crate::analyze::analyzer::Typed;
 use crate::analyze::typed_ast::Op;
 use crate::analyze::typed_ast::{Block, Ident, Type, Value};
-use compact_str::CompactStr;
+use compact_str::CompactString;
 
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -29,7 +29,7 @@ pub enum Expr {
 #[derive(Debug, Clone)]
 pub enum LiteralExpr {
     Integer(i64),
-    String(CompactStr),
+    String(CompactString),
     Float(f64),
     Bool(bool),
     Char(char),

--- a/src/analyze/typed_ast/ident.rs
+++ b/src/analyze/typed_ast/ident.rs
@@ -1,13 +1,13 @@
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use std::borrow::Borrow;
 use std::ops::Deref;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct Ident(pub CompactStr);
+pub struct Ident(pub CompactString);
 
 impl<T> From<T> for Ident
 where
-    T: Into<CompactStr>,
+    T: Into<CompactString>,
 {
     fn from(s: T) -> Self {
         Ident(s.into())
@@ -15,7 +15,7 @@ where
 }
 
 impl Deref for Ident {
-    type Target = CompactStr;
+    type Target = CompactString;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ macro_rules! fn_args {
         {
             let mut _map = fnv::FnvHashMap::default();
             $(
-                _map.insert(compact_str::CompactStr::from($k), $crate::interpreter::Value::from($v));
+                _map.insert(compact_str::CompactString::from($k), $crate::interpreter::Value::from($v));
             )*
             _map
         }

--- a/src/wasm/rt/mod.rs
+++ b/src/wasm/rt/mod.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use ahash::AHashMap;
 use cfg_if::cfg_if;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use wasmtime::{
     AsContext, AsContextMut, Caller, Config, Engine, Extern,
     Instance, Linker, Memory, MemoryType, Module, OptLevel, Store,
@@ -16,7 +16,7 @@ mod context;
 pub struct Runtime {
     engine: Engine,
     store: Store<Context>,
-    modules: AHashMap<CompactStr, Module>,
+    modules: AHashMap<CompactString, Module>,
     linker: Linker<Context>,
 }
 
@@ -46,7 +46,7 @@ impl Runtime {
 
     pub fn compile(
         &mut self,
-        name: CompactStr,
+        name: CompactString,
         binary: &[u8],
     ) -> anyhow::Result<()> {
         self.modules

--- a/src/wasm/scope.rs
+++ b/src/wasm/scope.rs
@@ -1,6 +1,6 @@
 use crate::analyze::typed_ast::{FuncType, Type};
 use ahash::AHashMap;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 
 #[derive(Debug, Clone)]
 pub enum Symbol {
@@ -11,12 +11,12 @@ pub enum Symbol {
 #[derive(Debug, Clone)]
 pub enum Scope {
     Global {
-        symbols: AHashMap<CompactStr, Symbol>,
+        symbols: AHashMap<CompactString, Symbol>,
         func_idx: u32,
         local_idx: u32,
     },
     Local {
-        symbols: AHashMap<CompactStr, Symbol>,
+        symbols: AHashMap<CompactString, Symbol>,
         local_idx: u32,
         if_depth: u32,
     },
@@ -37,7 +37,7 @@ impl Scope {
         .ok_or_else(|| anyhow::anyhow!("Symbol {} not found", name))
     }
 
-    pub fn set_symbol(&mut self, name: CompactStr, ty: Type) -> u32 {
+    pub fn set_symbol(&mut self, name: CompactString, ty: Type) -> u32 {
         match self {
             Scope::Global {
                 symbols,


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning